### PR TITLE
PR1: protocol compatibility scaffold for pickup wait_seconds

### DIFF
--- a/server/protocol/codec.go
+++ b/server/protocol/codec.go
@@ -143,10 +143,23 @@ func DecodePickupMessage(payload []byte) (*PickupMessageRequest, error) {
 	}
 
 	timeoutSeconds := int(binary.BigEndian.Uint32(payload[offset : offset+4]))
+	offset += 4
+
+	waitSeconds := 0
+	switch len(payload) - offset {
+	case 0:
+		// Backward-compatible shape: queue_name + timeout_seconds
+	case 4:
+		// New shape: queue_name + timeout_seconds + wait_seconds
+		waitSeconds = int(binary.BigEndian.Uint32(payload[offset : offset+4]))
+	default:
+		return nil, io.ErrUnexpectedEOF
+	}
 
 	return &PickupMessageRequest{
 		QueueName:      queueName,
 		TimeoutSeconds: timeoutSeconds,
+		WaitSeconds:    waitSeconds,
 	}, nil
 }
 

--- a/server/protocol/codec_test.go
+++ b/server/protocol/codec_test.go
@@ -52,6 +52,7 @@ func TestEncodeDecodePickupMessage(t *testing.T) {
 	req := &PickupMessageRequest{
 		QueueName:      "test-queue",
 		TimeoutSeconds: 30,
+		WaitSeconds:    0,
 	}
 
 	buf := writeString(req.QueueName)
@@ -72,6 +73,41 @@ func TestEncodeDecodePickupMessage(t *testing.T) {
 	}
 	if decoded.TimeoutSeconds != req.TimeoutSeconds {
 		t.Errorf("Expected timeout %d, got %d", req.TimeoutSeconds, decoded.TimeoutSeconds)
+	}
+	if decoded.WaitSeconds != req.WaitSeconds {
+		t.Errorf("Expected wait %d, got %d", req.WaitSeconds, decoded.WaitSeconds)
+	}
+}
+
+func TestDecodePickupMessageWithWaitSeconds(t *testing.T) {
+	req := &PickupMessageRequest{
+		QueueName:      "test-queue",
+		TimeoutSeconds: 30,
+		WaitSeconds:    5,
+	}
+
+	buf := writeString(req.QueueName)
+	timeoutBuf := make([]byte, 4)
+	timeoutBuf[3] = 30
+	buf = append(buf, timeoutBuf...)
+
+	waitBuf := make([]byte, 4)
+	waitBuf[3] = 5
+	buf = append(buf, waitBuf...)
+
+	decoded, err := DecodePickupMessage(buf)
+	if err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+
+	if decoded.QueueName != req.QueueName {
+		t.Errorf("Expected queue name '%s', got '%s'", req.QueueName, decoded.QueueName)
+	}
+	if decoded.TimeoutSeconds != req.TimeoutSeconds {
+		t.Errorf("Expected timeout %d, got %d", req.TimeoutSeconds, decoded.TimeoutSeconds)
+	}
+	if decoded.WaitSeconds != req.WaitSeconds {
+		t.Errorf("Expected wait %d, got %d", req.WaitSeconds, decoded.WaitSeconds)
 	}
 }
 

--- a/server/protocol/commands.go
+++ b/server/protocol/commands.go
@@ -44,6 +44,7 @@ type AddMessageResponse struct {
 type PickupMessageRequest struct {
 	QueueName      string
 	TimeoutSeconds int
+	WaitSeconds    int
 }
 
 type PickupMessageResponse struct {


### PR DESCRIPTION
Implements PR 1 from LONG_POLL_PR_PLAN.

Changes:
- Extend pickup request decoding to accept legacy payload (queue_name + timeout_seconds) and new payload (queue_name + timeout_seconds + wait_seconds).
- Add WaitSeconds to PickupMessageRequest, defaulting to 0 when omitted.
- Keep pickup runtime behavior unchanged.
- Add codec tests for both payload shapes and backward compatibility.

Notes:
- No behavior change in queue/tcp handling in this PR.