### PR TITLE
PR2: queue long-poll internals and blocking pickup

### DIFF
--- a/server/queue/queue.go
+++ b/server/queue/queue.go
@@ -15,34 +15,61 @@ type Queue struct {
 	name     string
 	messages []*Message
 	mu       sync.Mutex
+	cond     *sync.Cond
 }
 
 func NewQueue(name string) *Queue {
-	return &Queue{
+	q := &Queue{
 		name:     name,
 		messages: make([]*Message, 0),
 	}
+	q.cond = sync.NewCond(&q.mu)
+	return q
 }
 
 func (q *Queue) Add(msg *Message) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.messages = append(q.messages, msg)
+	q.cond.Broadcast()
 }
 
 func (q *Queue) Pickup(timeoutSeconds int) (*Message, error) {
+	return q.PickupWithWait(timeoutSeconds, 0)
+}
+
+func (q *Queue) PickupWithWait(timeoutSeconds int, waitSeconds int) (*Message, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	for _, msg := range q.messages {
-		if msg.State == StateAvailable {
-			msg.State = StatePickedUp
-			msg.TimeoutAt = time.Now().Add(time.Duration(timeoutSeconds) * time.Second)
+	if msg, ok := q.pickupAvailableLocked(timeoutSeconds); ok {
+		return msg, nil
+	}
+
+	if waitSeconds <= 0 {
+		return nil, ErrQueueEmpty
+	}
+
+	deadline := time.Now().Add(time.Duration(waitSeconds) * time.Second)
+
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, ErrQueueEmpty
+		}
+
+		timer := time.AfterFunc(remaining, func() {
+			q.mu.Lock()
+			q.cond.Broadcast()
+			q.mu.Unlock()
+		})
+		q.cond.Wait()
+		timer.Stop()
+
+		if msg, ok := q.pickupAvailableLocked(timeoutSeconds); ok {
 			return msg, nil
 		}
 	}
-
-	return nil, ErrQueueEmpty
 }
 
 func (q *Queue) Delete(id string) error {
@@ -73,6 +100,10 @@ func (q *Queue) RequeueTimedOut() int {
 		}
 	}
 
+	if count > 0 {
+		q.cond.Broadcast()
+	}
+
 	return count
 }
 
@@ -97,4 +128,15 @@ func (q *Queue) AvailableCount() int {
 
 func (q *Queue) Name() string {
 	return q.name
+}
+
+func (q *Queue) pickupAvailableLocked(timeoutSeconds int) (*Message, bool) {
+	for _, msg := range q.messages {
+		if msg.State == StateAvailable {
+			msg.State = StatePickedUp
+			msg.TimeoutAt = time.Now().Add(time.Duration(timeoutSeconds) * time.Second)
+			return msg, true
+		}
+	}
+	return nil, false
 }

--- a/server/queue/queue_test.go
+++ b/server/queue/queue_test.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -141,5 +142,82 @@ func TestQueueConcurrency(t *testing.T) {
 
 	if q.Size() < 50 {
 		t.Error("Queue should have at least 50 messages after concurrent operations")
+	}
+}
+
+func TestQueuePickupWithWaitWakesOnAdd(t *testing.T) {
+	q := NewQueue("test-queue")
+
+	done := make(chan *Message, 1)
+	go func() {
+		msg, err := q.PickupWithWait(10, 1)
+		if err != nil {
+			done <- nil
+			return
+		}
+		done <- msg
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	msg, _ := NewMessage("hello", "check")
+	q.Add(msg)
+
+	select {
+	case picked := <-done:
+		if picked == nil {
+			t.Fatal("expected pickup to succeed after add")
+		}
+		if picked.ID != msg.ID {
+			t.Fatalf("expected message %s, got %s", msg.ID, picked.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for pickup")
+	}
+}
+
+func TestQueuePickupWithWaitTimesOut(t *testing.T) {
+	q := NewQueue("test-queue")
+
+	start := time.Now()
+	_, err := q.PickupWithWait(10, 1)
+	elapsed := time.Since(start)
+	if err != ErrQueueEmpty {
+		t.Fatalf("expected ErrQueueEmpty, got %v", err)
+	}
+	if elapsed < 900*time.Millisecond {
+		t.Fatalf("pickup returned too quickly: %v", elapsed)
+	}
+}
+
+func TestQueuePickupWithWaitMultipleWaiters(t *testing.T) {
+	q := NewQueue("test-queue")
+
+	const waiters = 3
+	var wg sync.WaitGroup
+	wg.Add(waiters)
+
+	results := make(chan error, waiters)
+	for i := 0; i < waiters; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := q.PickupWithWait(10, 2)
+			results <- err
+		}()
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	for i := 0; i < waiters; i++ {
+		msg, _ := NewMessage("message", "check")
+		q.Add(msg)
+	}
+
+	wg.Wait()
+	close(results)
+
+	for err := range results {
+		if err != nil {
+			t.Fatalf("expected waiter to receive message, got err %v", err)
+		}
 	}
 }


### PR DESCRIPTION
Implements PR 2 from LONG_POLL_PR_PLAN.

Changes:
- Add waiter signaling in queue internals with sync.Cond.
- Add PickupWithWait(timeoutSeconds, waitSeconds) with blocking semantics:
  - returns immediately when a message is available
  - waits up to wait_seconds when queue is empty
  - returns empty on deadline
- Preserve FIFO + atomic pickup behavior under lock.
- Broadcast to waiters on Add and RequeueTimedOut.
- Add queue tests for wake-on-add, timeout, and multiple waiters.

Notes:
- Existing Pickup(timeoutSeconds) remains and delegates to wait=0.