### PR TITLE
PR5: add long-poll rollout metrics

### DIFF
--- a/server/metrics/prometheus.go
+++ b/server/metrics/prometheus.go
@@ -19,6 +19,9 @@ type Collector struct {
 	messagesPickedUp  atomic.Uint64
 	messagesDeleted   atomic.Uint64
 	messagesTimedOut  atomic.Uint64
+	pickupWaits       atomic.Uint64
+	pickupWaitNanos   atomic.Uint64
+	emptyAfterWait    atomic.Uint64
 	activeConnections atomic.Int32
 }
 
@@ -43,6 +46,18 @@ func (c *Collector) IncrMessagesDeleted() {
 
 func (c *Collector) IncrMessagesTimedOut() {
 	c.messagesTimedOut.Add(1)
+}
+
+func (c *Collector) IncrPickupWaits() {
+	c.pickupWaits.Add(1)
+}
+
+func (c *Collector) ObservePickupWaitDuration(d time.Duration) {
+	c.pickupWaitNanos.Add(uint64(d.Nanoseconds()))
+}
+
+func (c *Collector) IncrEmptyAfterWait() {
+	c.emptyAfterWait.Add(1)
 }
 
 func (c *Collector) IncrActiveConnections() {
@@ -96,6 +111,18 @@ func (c *Collector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "# HELP bbmb_messages_timed_out_total Total messages timed out\n")
 	fmt.Fprintf(w, "# TYPE bbmb_messages_timed_out_total counter\n")
 	fmt.Fprintf(w, "bbmb_messages_timed_out_total %d\n", c.messagesTimedOut.Load())
+
+	fmt.Fprintf(w, "# HELP bbmb_pickup_waits_total Total pickup requests with long-poll wait enabled\n")
+	fmt.Fprintf(w, "# TYPE bbmb_pickup_waits_total counter\n")
+	fmt.Fprintf(w, "bbmb_pickup_waits_total %d\n", c.pickupWaits.Load())
+
+	fmt.Fprintf(w, "# HELP bbmb_pickup_wait_duration_seconds_total Total wall time spent in long-poll waits\n")
+	fmt.Fprintf(w, "# TYPE bbmb_pickup_wait_duration_seconds_total counter\n")
+	fmt.Fprintf(w, "bbmb_pickup_wait_duration_seconds_total %.6f\n", float64(c.pickupWaitNanos.Load())/1e9)
+
+	fmt.Fprintf(w, "# HELP bbmb_empty_after_wait_total Total long-poll pickup requests that returned empty\n")
+	fmt.Fprintf(w, "# TYPE bbmb_empty_after_wait_total counter\n")
+	fmt.Fprintf(w, "bbmb_empty_after_wait_total %d\n", c.emptyAfterWait.Load())
 
 	fmt.Fprintf(w, "# HELP bbmb_active_connections Current number of active connections\n")
 	fmt.Fprintf(w, "# TYPE bbmb_active_connections gauge\n")

--- a/server/metrics/prometheus_test.go
+++ b/server/metrics/prometheus_test.go
@@ -47,3 +47,27 @@ func TestServeHTTPEscapesQueueLabelValue(t *testing.T) {
 		t.Fatalf("expected escaped queue label in metrics output, got: %s", body)
 	}
 }
+
+func TestServeHTTPIncludesLongPollMetrics(t *testing.T) {
+	manager := queue.NewManager()
+	collector := NewCollector(manager)
+	collector.IncrPickupWaits()
+	collector.IncrPickupWaits()
+	collector.ObservePickupWaitDuration(1500000000)
+	collector.IncrEmptyAfterWait()
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	rec := httptest.NewRecorder()
+	collector.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "bbmb_pickup_waits_total 2") {
+		t.Fatalf("expected pickup waits metric, got: %s", body)
+	}
+	if !strings.Contains(body, "bbmb_pickup_wait_duration_seconds_total 1.500000") {
+		t.Fatalf("expected pickup wait duration metric, got: %s", body)
+	}
+	if !strings.Contains(body, "bbmb_empty_after_wait_total 1") {
+		t.Fatalf("expected empty-after-wait metric, got: %s", body)
+	}
+}

--- a/server/tcp/server.go
+++ b/server/tcp/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"time"
 
 	"github.com/edsalkeld/bbmb/server/metrics"
 	"github.com/edsalkeld/bbmb/server/protocol"
@@ -159,8 +160,20 @@ func (s *Server) handlePickupMessage(payload []byte) []byte {
 		})
 	}
 
+	waitStart := time.Time{}
+	if req.WaitSeconds > 0 {
+		s.collector.IncrPickupWaits()
+		waitStart = time.Now()
+	}
+
 	msg, err := q.PickupWithWait(req.TimeoutSeconds, req.WaitSeconds)
+	if req.WaitSeconds > 0 {
+		s.collector.ObservePickupWaitDuration(time.Since(waitStart))
+	}
 	if err == queue.ErrQueueEmpty {
+		if req.WaitSeconds > 0 {
+			s.collector.IncrEmptyAfterWait()
+		}
 		return protocol.EncodePickupMessageResponse(&protocol.PickupMessageResponse{
 			Status: protocol.StatusEmptyQueue,
 		})


### PR DESCRIPTION
Implements PR 5 from LONG_POLL_PR_PLAN.

Changes:
- Add long-poll metrics:
  - bbmb_pickup_waits_total
  - bbmb_pickup_wait_duration_seconds_total
  - bbmb_empty_after_wait_total
- Track these metrics in the TCP pickup handler for wait-enabled requests.
- Add metric output tests covering new counters and duration value formatting.