### PR TITLE
build: strip server release binaries

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Build
       working-directory: ./server
-      run: go build -v .
+      run: go build -trimpath -ldflags="-s -w" -v .
 
     - name: Run tests
       working-directory: ./server

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ PY_CLIENT_DIR := python-client
 
 SERVER_BIN := $(SERVER_DIR)/bbmb-server
 GO_CLIENT_BIN := $(GO_CLIENT_DIR)/bbmb-client
+SERVER_GOFLAGS := -trimpath
+SERVER_LDFLAGS := -s -w
 
 help:
 	@echo "Available targets:"
@@ -28,16 +30,16 @@ help:
 	@echo "  clean                       Remove build artifacts"
 
 server-build:
-	cd $(SERVER_DIR) && go build -o bbmb-server .
+	cd $(SERVER_DIR) && go build $(SERVER_GOFLAGS) -ldflags='$(SERVER_LDFLAGS)' -o bbmb-server .
 
 server-build-portable:
-	cd $(SERVER_DIR) && CGO_ENABLED=0 go build -o bbmb-server .
+	cd $(SERVER_DIR) && CGO_ENABLED=0 go build $(SERVER_GOFLAGS) -ldflags='$(SERVER_LDFLAGS)' -o bbmb-server .
 
 server-build-linux-amd64:
-	cd $(SERVER_DIR) && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bbmb-server-linux-amd64 .
+	cd $(SERVER_DIR) && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(SERVER_GOFLAGS) -ldflags='$(SERVER_LDFLAGS)' -o bbmb-server-linux-amd64 .
 
 server-build-linux-arm64:
-	cd $(SERVER_DIR) && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bbmb-server-linux-arm64 .
+	cd $(SERVER_DIR) && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(SERVER_GOFLAGS) -ldflags='$(SERVER_LDFLAGS)' -o bbmb-server-linux-arm64 .
 
 server-run:
 	cd $(SERVER_DIR) && ./bbmb-server

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A lightweight, high-performance TCP-based message broker with FIFO queues, writt
 
 ```bash
 cd server
-go build -o bbmb-server .
+go build -trimpath -ldflags="-s -w" -o bbmb-server .
 ./bbmb-server
 
 # Optional: override the default listen ports
@@ -195,7 +195,7 @@ Use the included unit file at `deploy/systemd/bbmb.service`.
 ```bash
 # Build and install the server binary
 cd server
-go build -o bbmb-server .
+go build -trimpath -ldflags="-s -w" -o bbmb-server .
 sudo install -m 0755 bbmb-server /usr/local/bin/bbmb-server
 
 # Create runtime user and state directory


### PR DESCRIPTION
## Summary
- strip server build artifacts with `-trimpath -ldflags="-s -w"`
- apply the same flags to Makefile server targets and CI build examples
- keep the release workflow using the existing Make target so published binaries shrink without changing runtime behaviour

## Validation
- `cd server && go test ./...`
- `cd server && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags='-s -w' -o bbmb-server-linux-amd64 .`
